### PR TITLE
[ feat ] 버튼 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,3 @@
-
 export default function App() {
-  return (
-    <div>App</div>
-  )
+  return <div>App</div>;
 }

--- a/src/lib/Button/index.stories.tsx
+++ b/src/lib/Button/index.stories.tsx
@@ -1,0 +1,52 @@
+import { Meta, StoryObj } from "@storybook/react";
+import Button from ".";
+
+interface ButtonOwnProps {
+  size?: "small" | "middle" | "large";
+  type?: "free" | "bottom";
+  color?: "purple" | "pink" | "green" | "grey";
+  disabled?: boolean;
+}
+
+type ButtonStoryProps = ButtonOwnProps & { children: string };
+
+export default {
+  title: "Components/Button",
+  component: Button,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+    backgrounds: {
+      default: "dark",
+      values: [{ name: "dark", value: "#0D0E11" }],
+    },
+  },
+} as Meta<ButtonStoryProps>;
+
+// 기본 버튼
+export const Default: StoryObj<ButtonStoryProps> = {
+  args: {
+    children: "Default Button",
+    disabled: false,
+  },
+};
+
+// free 버튼
+export const Free: StoryObj<ButtonStoryProps> = {
+  args: {
+    children: "Free Button",
+    size: "large",
+    color: "green",
+    disabled: false,
+  },
+};
+
+// 바닥 버튼
+export const Bottom: StoryObj<ButtonStoryProps> = {
+  args: {
+    children: "Bottom Button",
+    type: "bottom",
+    color: "green",
+    disabled: false,
+  },
+};

--- a/src/lib/Button/index.stories.tsx
+++ b/src/lib/Button/index.stories.tsx
@@ -4,7 +4,8 @@ import Button from ".";
 interface ButtonOwnProps {
   size?: "small" | "middle" | "large";
   type?: "free" | "bottom";
-  color?: "purple" | "pink" | "green" | "grey";
+  backgroundColor?: "purple" | "pink" | "green" | "grey";
+  color?: "white" | "black" | "grey";
   disabled?: boolean;
 }
 
@@ -36,7 +37,8 @@ export const Free: StoryObj<ButtonStoryProps> = {
   args: {
     children: "Free Button",
     size: "large",
-    color: "green",
+    backgroundColor: "green",
+    color: "black",
     disabled: false,
   },
 };
@@ -46,7 +48,8 @@ export const Bottom: StoryObj<ButtonStoryProps> = {
   args: {
     children: "Bottom Button",
     type: "bottom",
-    color: "green",
+    backgroundColor: "green",
+    color: "black",
     disabled: false,
   },
 };

--- a/src/lib/Button/index.tsx
+++ b/src/lib/Button/index.tsx
@@ -1,22 +1,31 @@
 import { ReactNode } from "react";
-import { buttonColor, buttonContainer, buttonSize, buttonType } from "./style.css";
+import { buttonBackgroundColor, buttonColor, buttonContainer, buttonSize, buttonType } from "./style.css";
 
 interface ButtonProps {
   children: ReactNode;
   size?: "small" | "middle" | "large";
   type?: "free" | "bottom";
-  color?: "purple" | "pink" | "green" | "grey";
+  backgroundColor?: "purple" | "pink" | "green" | "grey";
+  color?: "white" | "black" | "grey";
   disabled?: boolean;
 }
 
 export default function Button(props: ButtonProps) {
-  const { size = "large", type = "free", color = "purple", disabled, children, ...restProps } = props;
+  const {
+    size = "large",
+    type = "free",
+    backgroundColor = "purple",
+    color = "white",
+    disabled,
+    children,
+    ...restProps
+  } = props;
 
   return (
     <div className={buttonContainer}>
       <button
         type="button"
-        className={`${buttonSize[size]} ${buttonType[type]} ${buttonColor[color]}`}
+        className={`${buttonSize[size]} ${buttonType[type]} ${buttonBackgroundColor[backgroundColor]} ${buttonColor[color]}`}
         disabled={disabled}>
         {children}
       </button>

--- a/src/lib/Button/index.tsx
+++ b/src/lib/Button/index.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from "react";
-import { buttonBase, buttonColor, buttonSize, buttonType } from "./style.css";
+import { buttonColor, buttonContainer, buttonSize, buttonType } from "./style.css";
 
 interface ButtonProps {
   children: ReactNode;
@@ -13,11 +13,13 @@ export default function Button(props: ButtonProps) {
   const { size = "large", type = "free", color = "purple", disabled, children, ...restProps } = props;
 
   return (
-    <button
-      type="button"
-      className={`${buttonBase} ${buttonSize[size]} ${buttonType[type]} ${buttonColor[color]}`}
-      disabled={disabled}>
-      {children}
-    </button>
+    <div className={buttonContainer}>
+      <button
+        type="button"
+        className={`${buttonSize[size]} ${buttonType[type]} ${buttonColor[color]}`}
+        disabled={disabled}>
+        {children}
+      </button>
+    </div>
   );
 }

--- a/src/lib/Button/index.tsx
+++ b/src/lib/Button/index.tsx
@@ -1,0 +1,23 @@
+import { ReactNode } from "react";
+import { buttonBase, buttonColor, buttonSize, buttonType } from "./style.css";
+
+interface ButtonProps {
+  children: ReactNode;
+  size?: "small" | "middle" | "large";
+  type?: "free" | "bottom";
+  color?: "purple" | "pink" | "green" | "grey";
+  disabled?: boolean;
+}
+
+export default function Button(props: ButtonProps) {
+  const { size = "large", type = "free", color = "purple", disabled, children, ...restProps } = props;
+
+  return (
+    <button
+      type="button"
+      className={`${buttonBase} ${buttonSize[size]} ${buttonType[type]} ${buttonColor[color]}`}
+      disabled={disabled}>
+      {children}
+    </button>
+  );
+}

--- a/src/lib/Button/style.css.ts
+++ b/src/lib/Button/style.css.ts
@@ -15,6 +15,12 @@ export const buttonContainer = style({
 
 export const buttonBase = style({
   border: "0px",
+  fontFamily: "Alexandria",
+  fontSize: "1.6rem",
+  fontStyle: "normal",
+  fontWeight: "400",
+  lineHeight: "normal",
+  letterSpacing: "-0.016rem",
 });
 
 export const buttonSize = styleVariants({
@@ -28,9 +34,15 @@ export const buttonType = styleVariants({
   bottom: { position: "absolute", bottom: "0", height: "7.5rem" },
 });
 
+export const buttonBackgroundColor = styleVariants({
+  purple: { backgroundColor: "#5200FF" },
+  pink: { backgroundColor: "#E965FF" },
+  green: { backgroundColor: "#43FF8E" },
+  grey: { backgroundColor: "#1E2025" },
+});
+
 export const buttonColor = styleVariants({
-  purple: { backgroundColor: "#5200FF", color: "white" },
-  pink: { backgroundColor: "#E965FF", color: "#0D0E11" },
-  green: { backgroundColor: "#43FF8E", color: "#0D0E11" },
-  grey: { backgroundColor: "#1E2025", color: "#9EA1AB" },
+  white: { color: "white" },
+  black: { color: "#0D0E11" },
+  grey: { color: "#9EA1AB" },
 });

--- a/src/lib/Button/style.css.ts
+++ b/src/lib/Button/style.css.ts
@@ -1,0 +1,32 @@
+import { style, styleVariants } from "@vanilla-extract/css";
+
+export const center = style({
+  display: "flex",
+  justifyContent: "center",
+  alignContent: "center",
+});
+
+export const buttonBase = style({
+  display: "flex",
+  justifyContent: "center",
+  alignContent: "center",
+  minWidth: "max-content",
+});
+
+export const buttonSize = styleVariants({
+  small: { padding: "1.1rem 1.2rem", height: "3.2rem", minWidth: "8.6rem" },
+  middle: { height: "4.8rem", minWidth: "8.6rem" },
+  large: { width: "100%" },
+});
+
+export const buttonType = styleVariants({
+  free: { borderRadius: "50%", height: "5.2rem" },
+  bottom: { position: "absolute", bottom: "0", height: "7.5rem" },
+});
+
+export const buttonColor = styleVariants({
+  purple: { backgroundColor: "#5200FF", color: "white" },
+  pink: { backgroundColor: "#E965FF", color: "#0D0E11" },
+  green: { backgroundColor: "#43FF8E", color: "#0D0E11" },
+  grey: { backgroundColor: "#1E2025", color: "#9EA1AB" },
+});

--- a/src/lib/Button/style.css.ts
+++ b/src/lib/Button/style.css.ts
@@ -6,21 +6,25 @@ export const center = style({
   alignContent: "center",
 });
 
-export const buttonBase = style({
+export const buttonContainer = style({
   display: "flex",
   justifyContent: "center",
   alignContent: "center",
   minWidth: "max-content",
 });
 
+export const buttonBase = style({
+  border: "0px",
+});
+
 export const buttonSize = styleVariants({
-  small: { padding: "1.1rem 1.2rem", height: "3.2rem", minWidth: "8.6rem" },
-  middle: { height: "4.8rem", minWidth: "8.6rem" },
-  large: { width: "100%" },
+  small: [buttonBase, { padding: "1.1rem 1.2rem", height: "3.2rem", minWidth: "8.6rem" }],
+  middle: [buttonBase, { height: "4.8rem", minWidth: "28.8rem" }],
+  large: [buttonBase, { width: "100%", minWidth: "34rem" }],
 });
 
 export const buttonType = styleVariants({
-  free: { borderRadius: "50%", height: "5.2rem" },
+  free: { borderRadius: "4rem", height: "5.2rem" },
   bottom: { position: "absolute", bottom: "0", height: "7.5rem" },
 });
 


### PR DESCRIPTION
## 🔥 Related Issues

- close #2 

## 💙 작업 내용

- 다음의 버튼들을 구현했습니다.
<img width="131" alt="스크린샷 2023-12-11 오후 5 51 03" src="https://github.com/Track-1/design-system/assets/76681519/f807ac25-abe6-49cf-804b-c990c4adc857">

<img width="554" alt="스크린샷 2023-12-11 오후 5 51 19" src="https://github.com/Track-1/design-system/assets/76681519/c0ed46a0-8ac6-4a49-aab5-62961ceba8ff">

<img width="384" alt="스크린샷 2023-12-11 오후 5 51 44" src="https://github.com/Track-1/design-system/assets/76681519/cec5b84f-0ddb-4160-a7fa-68cb9aa372fd">

<img width="300" alt="스크린샷 2023-12-11 오후 5 51 32" src="https://github.com/Track-1/design-system/assets/76681519/208cfdf5-670f-4af5-bc72-fafd6109cb1b">

<br/>

- 다음의 children을 props로 받습니다.

```
interface ButtonProps {
  children: ReactNode;
  size?: "small" | "middle" | "large";
  type?: "free" | "bottom";
  backgroundColor?: "purple" | "pink" | "green" | "grey";
  color?: "white" | "black" | "grey";
  disabled?: boolean;
}

```

- 바닐라 익스트랙은 구체적인 수치를 prop으로 내려받을 수 없어서 다음과 같이 받았습니다! 
- type에서 free는 기본 라운드 버튼이고, bottom은 바닥에 붙는 버튼이에요! 
- 옵션들 내려주지 않아도, 구조분해할당하면서 기본값 설정해두었습니다! (보라색 free버튼이 기본값)

## 😡 Trouble Shooting

## 👀 스크린샷 / GIF / 링크

<img width="592" alt="스크린샷 2023-12-11 오후 6 28 30" src="https://github.com/Track-1/design-system/assets/76681519/19310917-ef50-4dbd-b3ec-8c97a2de48d9">
<img width="626" alt="스크린샷 2023-12-11 오후 6 28 43" src="https://github.com/Track-1/design-system/assets/76681519/3d5ce4c2-3764-4a7f-aa22-ff8182fc0ced">
<img width="656" alt="스크린샷 2023-12-11 오후 6 28 54" src="https://github.com/Track-1/design-system/assets/76681519/430c8fea-f273-4327-8c95-2e5488674d85">

